### PR TITLE
Bump version of Octokit to 4.0.1

### DIFF
--- a/src/Octokit.Extensions/Octokit.Extensions.csproj
+++ b/src/Octokit.Extensions/Octokit.Extensions.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Octokit" Version="0.32.0" />
+    <PackageReference Include="Octokit" Version="4.0.1" />
     <PackageReference Include="Polly" Version="6.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
I just discovered this package - it looks perfect for what I need.

Unfortunately, trying to pull it into a new project, I get

```
[CS0012] The type 'GitHubClient' is defined in an assembly that is not referenced. You must add a reference to assembly 'Octokit, Version=0.32.0.0, Culture=neutral, PublicKeyToken=null'.
```

I need some of the fixes & features in newer versions of Octokit, so I cant really go back to the old version.

It'd be great if you could merge and release this, so we can use it with the latest version of Octokit